### PR TITLE
<BUILD> 패키지 의존성 때문에 빌드 환경을 Java 8으로 Migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-# 빌드 스테이지
-FROM openjdk:11-jdk-slim as build
+ARG CS_API_KEY="CS_API_KEY"
+ARG CS_API_SECRET="CS_API_SECRET"
+ARG CS_FROM_NUMBER="CS_FROM_NUMBER"
+ARG SECRET="SECRET"
 
-# spring 유저와 그룹을 생성하고 해당 그룹:유저로 빌드를 함으로써 리스크를 최소화함
+# 빌드 스테이지
+FROM gradle:7.5.1-jdk8 as build
+
+# spring 그룹과 유저을 생성하고 해당 그룹:유저로 빌드를 함으로써 리스크를 최소화함
 RUN adduser --system --group spring
 RUN mkdir /workspace && mkdir /workspace/app
 RUN chown spring:spring /workspace/app
-
 
 USER spring:spring
 
@@ -19,19 +23,41 @@ COPY --chown=spring:spring build.gradle.kts settings.gradle.kts gradlew ./
 # 소스 코드 복사
 COPY --chown=spring:spring src src
 
+ENV COOL_SMS_API_KEY $CS_API_KEY
+ENV COOL_SMS_API_SECRET $CS_API_SECRET
+ENV COOL_SMS_FROM_NUMBER $CS_FROM_NUMBER
+ENV USER_AUTH_SECRET $SECRET
+
 # 빌드 실행
-RUN ./gradlew build
+RUN ./gradlew build -x test
 RUN mkdir -p build/libs/dependency && (cd build/libs/dependency; jar -xf ../*SNAPSHOT.jar)
 
+ENV COOL_SMS_API_KEY ${CS_API_KEY}
+ENV COOL_SMS_API_SECRET ${CS_API_SECRET}
+ENV COOL_SMS_FROM_NUMBER ${CS_FROM_NUMBER}
+ENV USER_AUTH_SECRET ${SECRET}
 
 # 실제
-FROM openjdk:11-jre-slim-buster
+FROM openjdk:8-jre-slim-buster
 
-# spring 유저와 그룹을 생성하고 해당 그룹:유저로 빌드를 함으로써 리스크를 최소화함
+# spring 유저와 그룹을 생성하고 해당 그룹:유저로 실행을 함으로써 리스크를 최소화함
 RUN adduser --system --group spring
 USER spring:spring
 
 VOLUME /tmp
+
+ARG COOL_SMS_API_KEY=""
+ENV COOL_SMS_API_KEY ${COOL_SMS_API_KEY}
+
+ARG COOL_SMS_API_SECRET=""
+ENV COOL_SMS_API_SECRET ${COOL_SMS_API_SECRET}
+
+ARG COOL_SMS_FROM_NUMBER=""
+ENV COOL_SMS_FROM_NUMBER ${COOL_SMS_FROM_NUMBER}
+
+ARG USER_AUTH_SECRET=""
+ENV USER_AUTH_SECRET ${USER_AUTH_SECRET}
+
 
 ARG DEPENDENCY=/workspace/app/build/libs/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 group = "com.samcho"
 version = "0.0.1-SNAPSHOT"
-java.sourceCompatibility = JavaVersion.VERSION_11
+java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
 	mavenCentral()
@@ -31,7 +31,7 @@ dependencies {
 tasks.withType<KotlinCompile> {
 	kotlinOptions {
 		freeCompilerArgs = listOf("-Xjsr305=strict")
-		jvmTarget = "11"
+		jvmTarget = "1.8"
 	}
 }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,12 @@
-spring:
-  profiles:
-    include: API-KEY
+coolsms:
+  api-key : ${COOL_SMS_API_KEY}
+  api-secret : ${COOL_SMS_API_SECRET}
+  from-number : ${COOL_SMS_FROM_NUMBER}
+  url: https://api.coolsms.co.kr
 
-server:
-  port: 8080
+user-auth :
+  secret : ${USER_AUTH_SECRET}
+  issuer : Sungmin Cho
+
+server :
+  port : 8080


### PR DESCRIPTION
CoolSms가 Java 8에 의존함에 따라 해당 프로젝트도 Java 8으로 바꾸는 것이 법적으로 귀책 사유가 없을 것이라 판단. 기존의 Java 11에서 Java 8으로 다운그레이드 후 Dockerfile을 그에 맞게 수정함.